### PR TITLE
Changed Swagger url to Swagger next, where loading from url still works.

### DIFF
--- a/apps/api-register/src/pages/apis/[id].astro
+++ b/apps/api-register/src/pages/apis/[id].astro
@@ -104,8 +104,8 @@ const details = error ? null : data;
           <DataBadgeLink href={`https://redocly.github.io/redoc/?url=${details?.oasUrl}`} target="_blank" rel="noopener" role="listitem">
             ReDoc
           </DataBadgeLink>
-          <DataBadgeLink href={`https://editor.swagger.io/?url=${details?.oasUrl}`} target="_blank" rel="noopener" role="listitem">
-            Swagger
+          <DataBadgeLink href={`https://editor-next.swagger.io/?url=${details?.oasUrl}`} target="_blank" rel="noopener" role="listitem">
+            Swagger (Next)
           </DataBadgeLink>
           <DataBadgeLink role="listitem" href={`https://elements-demo.stoplight.io/?spec=${details?.oasUrl}`} target="_blank" rel="noopener">
             Stoplight


### PR DESCRIPTION
Somehow direct loading from url did not work anymore. See issue #80 

The newer Swagger Next editor still does, so we use that...